### PR TITLE
Fix RTCConnection arguments in the mobile example

### DIFF
--- a/examples/mobile/README.md
+++ b/examples/mobile/README.md
@@ -283,7 +283,8 @@ myConnection = RTCConnection(rtcConfiguration=RTCConfiguration([
 ```
 
 ```javascript
-var conn = new rtcbot.RTCConnection(rtcConfiguration=[
+var conn = new rtcbot.RTCConnection(true, {
+                iceServers:[
                     { urls: ["stun:stun.l.google.com:19302"] },
                     { urls: "turn:my.server.ip:3478?transport=udp", 
                         username: "myusername", credential: "mypassword", },
@@ -340,7 +341,8 @@ myConnection = RTCConnection(rtcConfiguration=RTCConfiguration([
 ```
 
 ```javascript
-var conn = new rtcbot.RTCConnection(rtcConfiguration=[
+var conn = new rtcbot.RTCConnection(true, {
+                iceServers:[
                     { urls: ["stun:stun.l.google.com:19302"] },
                     { urls: "turn:<PUBLIC_NETWORK_IP:3478?transport=udp", 
                         username: "myusername", credential: "mypassword", },


### PR DESCRIPTION
I found RTCConnection arguments in the mobile example is wrong for javascript.

Passing named arguments works in Python, but not in JS, we need to change: `new rtcbot.RTCConnection(rtcConfiguration=[...])` to `new rtcbot.RTCConnection(true, {...})`.
