### PR TITLE
Add support for Picamera2 (default on Raspberry Pi OS bullseye)

### DIFF
--- a/docs/camera.rst
+++ b/docs/camera.rst
@@ -87,6 +87,30 @@ above, and it returns exactly the same data for the frame::
 
 This means that if not using CVDisplay, you don't even need OpenCV installed to stream from you raspberry pi.
 
+PiCamera2
+++++++++++++++++
+
+This allows you to use the official raspberry pi camera, with libcamera stack (legacy camera interface disabled).
+This is default since Raspberry Pi OS bullseye, PiCamera2 also works with 64-bit OS.
+You can use the parameter hflip=1 to flip the camera horizontally, vflip=1 to flip vertically, or both to rotate 180 degrees.
+You can use it in exactly the same way as the OpenCV camera above, and it returns exactly the same data for the frame::
+
+    import asyncio
+    from rtcbot import PiCamera2, CVDisplay
+
+    camera = PiCamera2()
+    display = CVDisplay()
+
+    display.putSubscription(camera)
+
+    try:
+        asyncio.get_event_loop().run_forever()
+    finally:
+        camera.close()
+        display.close()
+
+This means that if not using CVDisplay, you don't even need OpenCV installed to stream from you raspberry pi.
+
 API
 ++++++++++++++++
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -60,6 +60,7 @@ intersphinx_mapping = {
     "aiortc": ("https://aiortc.readthedocs.io/en/latest/", None),
     "inputs": ("https://inputs.readthedocs.io/en/latest/", None),
     "picamera": ("https://picamera.readthedocs.io/en/latest/", None),
+    "picamera2": ("https://datasheets.raspberrypi.com/camera/picamera2-manual.pdf", None),
 }
 
 # Add any paths that contain templates here, relative to this directory.

--- a/rtcbot/__init__.py
+++ b/rtcbot/__init__.py
@@ -1,7 +1,7 @@
 from .base import SubscriptionClosed
 from .connection import RTCConnection
 from .websocket import Websocket
-from .camera import CVCamera, PiCamera, CVDisplay
+from .camera import CVCamera, PiCamera, PiCamera2, CVDisplay
 from .audio import Microphone, Speaker
 from .inputs import Gamepad, Mouse, Keyboard
 from .arduino import SerialConnection


### PR DESCRIPTION
Raspberry Pi Ltd has switched totally to libcamera stack for their CSI cameras with new python library (picamera2) since 2020, and now it is the default on Raspberry Pi OS. picamera2 also works on 64-bit OS while deprecated picamera library (using legacy camera interface) doesn't.
This PR adds support for new picamera2 with PiCamera2. It also fixes and improves old PiCamera to allow setting camera parameters such as width, height, fps and rotation (to use in non-standard ways of arrangement).